### PR TITLE
Update NextAuth

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "clsx": "^1.1.1",
     "next": "^13.2.1",
     "next-auth": "^4.14.0",
+    "nodemailer": "^6.9.1",
     "pixijs": "^7.1.4",
     "prisma-json-types-generator": "^2.3.1",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,10 @@ dependencies:
     version: 13.2.1(react-dom@18.2.0)(react@18.2.0)(sass@1.62.0)
   next-auth:
     specifier: ^4.14.0
-    version: 4.17.0(next@13.2.1)(react-dom@18.2.0)(react@18.2.0)
+    version: 4.17.0(next@13.2.1)(nodemailer@6.9.1)(react-dom@18.2.0)(react@18.2.0)
+  nodemailer:
+    specifier: ^6.9.1
+    version: 6.9.1
   pixijs:
     specifier: ^7.1.4
     version: 7.1.4
@@ -2928,7 +2931,7 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
-  /next-auth@4.17.0(next@13.2.1)(react-dom@18.2.0)(react@18.2.0):
+  /next-auth@4.17.0(next@13.2.1)(nodemailer@6.9.1)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-aN2tdnjS0MDeUpB2tBDOaWnegkgeMWrsccujbXRGMJ607b+EwRcy63MFGSr0OAboDJEe0902piXQkt94GqF8Qw==}
     engines: {node: ^12.19.0 || ^14.15.0 || ^16.13.0 || ^18.12.0}
     peerDependencies:
@@ -2945,6 +2948,7 @@ packages:
       cookie: 0.5.0
       jose: 4.12.0
       next: 13.2.1(react-dom@18.2.0)(react@18.2.0)(sass@1.62.0)
+      nodemailer: 6.9.1
       oauth: 0.9.15
       openid-client: 5.3.0
       preact: 10.11.3
@@ -3060,6 +3064,11 @@ packages:
   /node-releases@2.0.6:
     resolution: {integrity: sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==}
     dev: true
+
+  /nodemailer@6.9.1:
+    resolution: {integrity: sha512-qHw7dOiU5UKNnQpXktdgQ1d3OFgRAekuvbJLcdG5dnEo/GtcTHRYM7+UfJARdOFU9WUQO8OiIamgWPmiSFHYAA==}
+    engines: {node: '>=6.0.0'}
+    dev: false
 
   /nopt@5.0.0:
     resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,18 +1,65 @@
 import NextAuth from "next-auth";
-import { AppProviders } from "next-auth/providers";
 import DiscordProvider from "next-auth/providers/discord";
+import GithubProvider from "next-auth/providers/github";
+import GoogleProvider from "next-auth/providers/google";
+import EmailProvider from "next-auth/providers/email";
 
-const providers: AppProviders = [];
-const clientId = process.env.DISCORD_CLIENT_ID;
-const clientSecret = process.env.DISCORD_CLIENT_SECRET;
+const providers = [];
 
-if (clientId !== undefined && clientSecret !== undefined) {
+if (process.env.DISCORD_CLIENT_ID && process.env.DISCORD_CLIENT_SECRET) {
   providers.push(
     DiscordProvider({
-      clientId,
-      clientSecret,
-    }),
+      clientId: process.env.DISCORD_CLIENT_ID,
+      clientSecret: process.env.DISCORD_CLIENT_SECRET,
+    })
   );
 }
 
-export default NextAuth({ providers });
+if (process.env.EMAIL_SERVER && process.env.EMAIL_FROM) {
+  providers.push(
+    EmailProvider({
+      server: process.env.EMAIL_SERVER,
+      from: process.env.EMAIL_FROM,
+    })
+  );
+}
+
+if (process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET) {
+  providers.push(
+    GithubProvider({
+      clientId: process.env.GITHUB_CLIENT_ID,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET,
+    })
+  );
+}
+
+if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+  providers.push(
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    })
+  );
+}
+
+export default NextAuth({
+  providers,
+
+  // The Email provider requires a database, we can comment this provider out until that is setup
+  // database: process.env.DATABASE_URL
+  
+  secret: process.env.SECRET,
+
+  pages: {
+    signIn: "/auth/signin",
+    signOut: "/auth/signout"
+  },
+
+  callbacks: {
+    async signIn({ user, account, profile, email, credentials }) {
+      return true;
+    },
+  },
+
+  debug: false,
+});


### PR DESCRIPTION
Rewrote the Next-Auth API/auth script to include a GitHub and Google OAuth sign-in provider, as well as added a passwordless email sign-in for backup access. I added a pages option with the sign-in and sign-out pages linked (will add those later). I also added a callbacks option, currently there is only the Sign-in callback which will be modified. I plan on using the callbacks to keep track of the session token to allow for account linking (Using Discord for sign-in, then converting to a regular User). I will do this with a JWT and session decryption callback.