### PR TITLE
Setting placeholder pages for existing Links

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,17 +8,14 @@ export function Footer() {
   return (
     <footer className="@flex @flex-col @items-center @justify-center @gap-4 @bg-gradient-to-t @from-black @p-0 @h-[140px]">
       <nav className="@flex @gap-8">
-        <Link className="@text-base-a" href="/">
-          Home
-        </Link>
-        <Link className="@text-base-a" href="/">
+        <Link className="@text-base-a" href="/about">
           About us
         </Link>
-        <Link className="@text-base-a" href="/">
+        <Link className="@text-base-a" href="/terms">
           Terms of Use
         </Link>
-        <Link className="@text-base-a" href="/">
-          Rules
+        <Link className="@text-base-a" href="/donations">
+          Donations
         </Link>
       </nav>
 

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,3 +1,4 @@
+import { Layout } from 'components/layout';
 import Link from 'next/link';
 import { useState } from 'react';
 import { trpc } from 'utils/trpc';
@@ -11,9 +12,13 @@ export default function AboutPage() {
   });
 
   return (
-    <div>
-      Here&apos;s a random number from a sub: {num} <br />
-      <Link href="/">Index</Link>
-    </div>
+    <Layout>
+      <div className="@text-center @w-[500px]">
+        <p>
+          Here&apos;s a random number from a sub: {num?.toFixed(5)} <br />
+        </p>
+        <Link href="/">Home</Link>
+      </div>
+    </Layout>
   );
 }

--- a/src/pages/donations/index.tsx
+++ b/src/pages/donations/index.tsx
@@ -1,7 +1,7 @@
 import { Layout } from 'components/layout';
 import Link from 'next/link';
 
-export default function HowToPlayPage() {
+export default function Donations() {
   return (
     <Layout>
       <div className="@text-center @w-[500px]">

--- a/src/pages/terms/index.tsx
+++ b/src/pages/terms/index.tsx
@@ -1,7 +1,7 @@
 import { Layout } from 'components/layout';
 import Link from 'next/link';
 
-export default function HowToPlayPage() {
+export default function TermsPage() {
   return (
     <Layout>
       <div className="@text-center @w-[500px]">


### PR DESCRIPTION
Establishing placeholders with basic styling and Navbar for Terms of Use and Donations. Linked About back to the original AboutPage for now.

All pages (with the exception of Login) now is linked to an established page instead of rerouting to "/" when clicked.