### PR TITLE
Fixed typo in tailwind.config.js

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,7 +17,7 @@ module.exports = {
       tablet: "480px",
       smallscreen: "768px",
       laptop: "1024px",
-      short: { raw: "(min-height): 600px" },
+      short: { raw: "(min-height: 600px)" },
       medium: { raw: "(min-height: 700px)" },
     },
   },


### PR DESCRIPTION
Find a small type in Tailwind config file while looking over the breakpoints. Fixed that here in this PR.