### PR TITLE
Add nodejs environment setup within docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18.15
+COPY package-lock.json /app/package-lock.json
+COPY package.json /app/package.json
+WORKDIR /app
+RUN npm install
+COPY . /app/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,5 +10,23 @@ services:
     environment:
       POSTGRES_PASSWORD: ${PGPASSWORD}
       POSTGRES_HOST_AUTH_METHOD: trust
+
+  app:
+    build:
+      dockerfile: Dockerfile
+    volumes:
+      - .:/app/
+      - /app/node_modules
+    ports:
+      - '3000:3000'
+      - '3001:3001'
+    command: ./run_app.sh
+    env_file:
+      - .env
+    depends_on:
+      - postgres
+    environment:
+      DB_URL: "postgresql://postgres:${PGPASSWORD}@postgres:5432/trpc-starter-websockets?schema=public"
+
 volumes:
   db_data:

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -14,9 +14,19 @@ const developmentPlayerNames = Array(4)
   .map((_, i) => `${developmentPlayerNamePrefix}${i}`);
 
 async function main() {
+  const SEED_USER_NAME: string = "development_user";
+
+  // NOTE: No need to seed data in db if seeded data already exists in db
+  const user = await prisma.user.findFirst({
+    where: { name: SEED_USER_NAME },
+  });
+  if (!!user) {
+    return;
+  }
+
   const developmentUser = await prisma.user.create({
     data: {
-      name: "development_user",
+      name: SEED_USER_NAME,
     },
   });
 

--- a/run_app.sh
+++ b/run_app.sh
@@ -1,0 +1,4 @@
+#bin/bash
+npm run prisma:push
+npm run prisma:seed
+npm run dev


### PR DESCRIPTION
### Current situation
- We have postgres maintained with docker-compose
- However, our node environment is maintained locally. The issue here is that all the contributors have to ensure that they have the right nodejs version `node:18.15.0.`. This inconsistency may cause issues down the line when differences in nodejs version amongst the contributors might affect the app functionality if the contributors did not maintain the right node version when running the codebase in their local environments.

### Suggestion
- Dockerize our nodejs environment. This ensures environment consistency. All contributors will now work `node:18.15.0` as defined in the Dockerfile

### Impact

### What will change with this?
- Contributors will use a single command `docker-compose up` instead of a combination of commands: `npm run dev` and `docker-compose up`
- `DATABASE_URL` is now maintained in `docker-compose.yaml` instead of `.env`
- If there is any package changes in `package.json`, contributors will need to execute `docker-compose build` instead of `npm install`
- Change the implementation of seeding data in DB: If data already exits, don't need to seed. `prisma/seed.ts`
- Now that node environment is within a docker container, if we want to execute node commands we have to enter the container and execute the commands there: `docker-compose exec <service_name> bash` which enters the container and then in the container you can execute the commands. 
