### PR TITLE
Menu update

### DIFF
--- a/src/pages/match/[matchId].tsx
+++ b/src/pages/match/[matchId].tsx
@@ -15,6 +15,7 @@ import {
   SCALE_MODES,
   Sprite,
   Spritesheet,
+  Texture,
 } from "pixi.js";
 import { useEffect, useRef, useState } from "react";
 import { PlayerInMatch } from "shared/types/server-match-state";
@@ -60,23 +61,25 @@ const Match = ({ spriteData }) => {
   //Important useEffect to make sure Pixi
   // only gets updated when pixiCanvasRef or mapData changes
   // we dont want it to be refreshed in react everytime something changes.
+
   useEffect(() => {
     const app = new Application({
       view: pixiCanvasRef.current,
       autoDensity: true,
       resolution: window.devicePixelRatio,
       backgroundColor: "#061838",
-      //TODO: The width needs to be = mapData[0].length * 16 + 16, but it seems it errors out if mapData isnt loaded well.
+      //TODO: I'd like our app to be the size of the map, not bigger or smaller.
+      // The width needs to be = mapData[0].length * 16 + 16, but it seems it errors out if mapData isnt loaded well.
       // However, mapData?.length seems to work well for the height.
-      width: 1400,
-      height: 2000,
+      width: window.outerWidth * 0.975,
+      height: window.outerHeight * 0.975,
       resizeTo: undefined,
     });
 
     //TODO: Button with + and - to change the scale of our stage, also needs
     // to have app.resize() working so we can resize the size of our app.
     app.stage.scale.set(2.6, 2.6);
-    app.stage.position.set(0, 16);
+    app.stage.position.set(0, 0);
 
     //let render our specific cursor
     //TODO: Cursor stops working on half screen?
@@ -85,7 +88,8 @@ const Match = ({ spriteData }) => {
     };
     //the container that holds everything
     const mapContainer = new Container();
-
+    mapContainer.x = 8;
+    mapContainer.y = 16;
     //allows for us to use zIndex on the children of mapContainer
     mapContainer.sortableChildren = true;
     app.stage.addChild(mapContainer);
@@ -128,21 +132,34 @@ const Match = ({ spriteData }) => {
                     rowIndex,
                     colIndex
                   );
-                  //lets make menu dissapear on hover out
-                  //TODO: Make menu dissapear if we click somewhere else
-                  menu.on("pointerleave", () => {
-                    console.log("menu pointerout");
-                    const length = mapContainer.children.length;
-                    mapContainer.removeChild(mapContainer.children[length - 1]);
+
+                  //if there is a menu already out, lets rempove it
+                  mapContainer.removeChild(mapContainer.getChildByName("menu"));
+
+                  //lets create a transparent screen that covers everything.
+                  // if we click on it, we will delete the menu
+                  // therefore, achieving a quick way to delete menu if we click out of it
+                  const emptyScreen = new Sprite(Texture.WHITE);
+                  emptyScreen.x = 0;
+                  emptyScreen.y = 0;
+                  emptyScreen.alpha = 0;
+                  emptyScreen.width = app.stage.width;
+                  emptyScreen.height = app.stage.height;
+                  emptyScreen.zIndex = -1;
+                  emptyScreen.eventMode = "static";
+                  emptyScreen.on("click", (event) => {
+                    mapContainer.removeChild(menu);
+                    mapContainer.removeChild(emptyScreen);
                   });
                   mapContainer.addChild(menu);
+                  mapContainer.addChild(emptyScreen);
                 });
               }
 
               //TODO: Seems like properties/buildings have different animation speeds...
               // gotta figure out how to make sure all buildings are animated properly
               // or at least AWBW seems to have different speeds/frames than Daemon's replayer
-              tile.animationSpeed = 0.03;
+              tile.animationSpeed = 0.04;
               tile.play();
               console.log(window.devicePixelRatio);
             }
@@ -173,8 +190,7 @@ const Match = ({ spriteData }) => {
   if (!spriteData) return <h1>Loading...</h1>;
   else {
     return (
-      <div className={"@m-10"}>
-        <h1>Basic pixi.js dev environment </h1>
+      <div>
         <canvas
           style={{
             imageRendering: "pixelated",
@@ -186,7 +202,6 @@ const Match = ({ spriteData }) => {
   }
 };
 export default Match;
-
 
 export async function getServerSideProps() {
   //TODO: Should we call all the spritesheets or just the ones the players will need?

--- a/src/pages/match/[matchId].tsx
+++ b/src/pages/match/[matchId].tsx
@@ -79,7 +79,7 @@ const Match = ({ spriteData }) => {
     //TODO: Button with + and - to change the scale of our stage, also needs
     // to have app.resize() working so we can resize the size of our app.
     app.stage.scale.set(2.6, 2.6);
-    app.stage.position.set(0, 0);
+    app.stage.position.set(0, 30);
 
     //let render our specific cursor
     //TODO: Cursor stops working on half screen?
@@ -124,13 +124,13 @@ const Match = ({ spriteData }) => {
                 tile.eventMode = "static";
                 //Lets make menu appear
                 tile.on("pointerdown", async () => {
-                  console.log("touched an action tile!");
                   const menu = await showMenu(
                     spriteSheets[slot],
                     type,
                     slot,
                     rowIndex,
-                    colIndex
+                    colIndex,
+                    mapData.length - 1,
                   );
 
                   //if there is a menu already out, lets rempove it
@@ -161,7 +161,6 @@ const Match = ({ spriteData }) => {
               // or at least AWBW seems to have different speeds/frames than Daemon's replayer
               tile.animationSpeed = 0.04;
               tile.play();
-              console.log(window.devicePixelRatio);
             }
 
             //NOT A PROPERTY

--- a/src/spriteSheet/showMenu.ts
+++ b/src/spriteSheet/showMenu.ts
@@ -19,6 +19,10 @@ export default async function showMenu(
   x: number,
   y: number
 ) {
+  //TODO: Gotta add a "funds" value to our parameters
+  // from there, include it here and any unit above our funds,
+  // will be darkened out.
+
   //The big container holding everything
   //set its eventmode to static for interactivity and sortable for zIndex
   const menuContainer = new Container();
@@ -47,6 +51,8 @@ export default async function showMenu(
     unitSprite.animationSpeed = 0.07;
     // try to make it "centered"
     unitSprite.anchor.set(-0.2, -0.2);
+    unitSprite.tint = "rgb(255,255,255)";
+
     unitSprite.play();
 
     const unitName = new BitmapText(`${unit.menuName}`, {
@@ -77,14 +83,12 @@ export default async function showMenu(
     //This will make ALL unitBGs change tint, even the ones on another menuElement
     menuElement.on("pointerenter", () => {
       unitBG.tint = "#ffffff";
-      unitSprite.textures = spriteSheet.animations[unit.name + "_mdown"];
-      unitSprite.play();
+      unitSprite.tint = "rgb(215,215,215)";
     });
 
     menuElement.on("pointerleave", () => {
       unitBG.tint = "#d3d3d3";
-      unitSprite.textures = spriteSheet.animations[unit.name];
-      unitSprite.play();
+      unitSprite.tint = "rgb(255,255,255)";
     });
 
     menuElement.addChild(unitBG);
@@ -104,7 +108,8 @@ export default async function showMenu(
   outerBorder.height = (unitInfo.length - 1) * 15.5;
   outerBorder.zIndex = -1;
   menuContainer.addChild(outerBorder);
-  menuContainer.x = x * 16 + 15;
+  menuContainer.x = x * 16 + 24;
   menuContainer.y = y * 16;
+  menuContainer.name = "menu";
   return menuContainer;
 }

--- a/src/spriteSheet/showMenu.ts
+++ b/src/spriteSheet/showMenu.ts
@@ -17,7 +17,8 @@ export default async function showMenu(
   type: string,
   slot: number,
   x: number,
-  y: number
+  y: number,
+  mapHeight: number
 ) {
   //TODO: Gotta add a "funds" value to our parameters
   // from there, include it here and any unit above our funds,
@@ -32,6 +33,15 @@ export default async function showMenu(
   //unitInfo brings back an array with all the data we need (such as infantry name, cost, etc).
   const unitInfo = await unitData(-1, type);
 
+  //if our menu would appear below the middle of the map, we need to bring it up!
+  // Otherwise, our user will have to scroll down to see all the units, which is a poor experience
+  if (y > mapHeight / 2) {
+    const spaceLeft = mapHeight - y;
+    //now if you wonder about 0.675, it basically means the
+    // menu element is 67.5% of a tile, so we only move that much
+    y = y - Math.abs(spaceLeft - unitInfo.length * 0.675);
+  }
+
   //lets load our font
   await Assets.load("/aw2Font.fnt");
 
@@ -41,7 +51,7 @@ export default async function showMenu(
     const menuElement = new Container();
     menuElement.eventMode = "static";
 
-    const yValue = index * 14;
+    const yValue = index * 12;
 
     //our unit image
     const unitSprite = new AnimatedSprite(spriteSheet.animations[unit.name]);
@@ -51,13 +61,12 @@ export default async function showMenu(
     unitSprite.animationSpeed = 0.07;
     // try to make it "centered"
     unitSprite.anchor.set(-0.2, -0.2);
-    unitSprite.tint = "rgb(255,255,255)";
 
     unitSprite.play();
 
     const unitName = new BitmapText(`${unit.menuName}`, {
       fontName: "awFont",
-      fontSize: 14,
+      fontSize: 12,
     });
     unitName.y = yValue;
     unitName.x = 15;
@@ -65,7 +74,7 @@ export default async function showMenu(
 
     const unitCost = new BitmapText(`${unit.cost}`, {
       fontName: "awFont",
-      fontSize: 12,
+      fontSize: 10,
     });
     unitCost.y = yValue;
     unitCost.x = 60;
@@ -75,20 +84,20 @@ export default async function showMenu(
     const unitBG = new Sprite(Texture.WHITE);
     unitBG.x = 0;
     unitBG.y = yValue;
-    unitBG.width = 90;
-    unitBG.height = 12;
-    unitBG.eventMode = "static";
-    unitBG.tint = "#d3d3d3";
+    unitBG.width = 84;
+    unitBG.height = 10;
 
-    //This will make ALL unitBGs change tint, even the ones on another menuElement
+    unitBG.eventMode = "static";
+    unitBG.tint = "#ffffff";
+    unitBG.alpha = 0.5;
+
+    //lets add a hover effect to our elements
     menuElement.on("pointerenter", () => {
-      unitBG.tint = "#ffffff";
-      unitSprite.tint = "rgb(215,215,215)";
+      unitBG.alpha = 1;
     });
 
     menuElement.on("pointerleave", () => {
-      unitBG.tint = "#d3d3d3";
-      unitSprite.tint = "rgb(255,255,255)";
+      unitBG.alpha = 0.5;
     });
 
     menuElement.addChild(unitBG);
@@ -104,12 +113,14 @@ export default async function showMenu(
   outerBorder.tint = "#8c8c8c";
   outerBorder.x = -2;
   outerBorder.y = -2;
-  outerBorder.width = 94;
-  outerBorder.height = (unitInfo.length - 1) * 15.5;
+  outerBorder.width = 88;
+  outerBorder.height = (unitInfo.length - 1) * 13.2;
   outerBorder.zIndex = -1;
   menuContainer.addChild(outerBorder);
   menuContainer.x = x * 16 + 24;
   menuContainer.y = y * 16;
+  outerBorder.alpha = 0.8;
+  //the name lets us find the menu easily with getChildByName for easy removal
   menuContainer.name = "menu";
   return menuContainer;
 }


### PR DESCRIPTION
# The update

https://github.com/WarsWorld/WarsWorld/assets/96269542/d7ac5b60-1b13-4e1b-8d5e-001413d2623d

Basically menus now only leave when clicking outside a menu (instead of hovering out), menus are removed if another menu appears (no more double menus) and now menus cannot appear below the map, they will instead move upwards to fit tightly and smoothly (no more scrolling down to build units).

Also fixed some minor animations and made the menus smaller.