### PR TITLE
Fix errors with frontend

### DIFF
--- a/src/shared/wrappers/match.ts
+++ b/src/shared/wrappers/match.ts
@@ -123,16 +123,24 @@ export class MatchWrapper {
   }
 
   addUnwrappedPlayer(player: PlayerInMatch): PlayerInMatchWrapper {
-    const teamIndex = this.rules.teamMapping[player.slot];
-    const foundTeam = this.teams.find((team) => team.index === teamIndex);
 
-    if (foundTeam === undefined) {
-      const team = new TeamWrapper([player], this, teamIndex)
-      this.teams.push(team);
-      return team.players[0];
+    //lets check if the rules have a teamMapping
+    if (this.rules.teamMapping !== undefined) {
+      //check for team
+      const teamIndex = this.rules.teamMapping[player.slot];
+      const foundTeam = this.teams?.find((team) => team.index === teamIndex);
+
+      //there is no team
+      if (foundTeam != undefined) {
+        return foundTeam.addUnwrappedPlayer(player);
+      }
     }
 
-    return foundTeam.addUnwrappedPlayer(player);
+    //no teamMapping
+    //TODO: if there's no teamMapping, I assume that then we can use the player.slot as the players default team index?
+    const team = new TeamWrapper([player], this, player.slot)
+    this.teams.push(team);
+    return team.players[0];
   }
 
   // UNIT STUFF ****************************************************************

--- a/src/shared/wrappers/player-in-match.ts
+++ b/src/shared/wrappers/player-in-match.ts
@@ -39,7 +39,13 @@ export class PlayerInMatchWrapper {
   }
 
   getUnits() {
-    return this.match.units.filter((u) => u.data.playerSlot === this.data.slot)
+
+    if (this.match.units !== undefined) {
+      return this.match.units.filter((u) => u.data.playerSlot === this.data.slot)
+    }
+
+    //TODO: If there are no units, is it okay to return an empty array?
+    return [];
   }
 
   getHook<HookType extends keyof Hooks>(hookType: HookType) {


### PR DESCRIPTION
There were some small errors (see image below) involving if there wasnt a teamMapping in a match and if there were no units in a match (or well, at least if units property wasn't defined in the match).

![image](https://github.com/WarsWorld/WarsWorld/assets/96269542/f4dea8c9-a658-465d-bf57-41aac16bc569)

These small fixes allow the frontend to get the current player via usePlayers() useContext implementation. Which therefore, allows devs to work on match creation.

# Important Note
If these fixes are already addressed in some work in progress you have function/pau, I appreciate if we could merge this anyways because its infinitely small but it allows us to effectively get the currentPlayer and other players in the frontend effectively, thanks!
