### PR TITLE
Added a context in your-matches page

### DIFF
--- a/src/frontend/components/match/CreateMatch.tsx
+++ b/src/frontend/components/match/CreateMatch.tsx
@@ -4,22 +4,20 @@ import Select from "frontend/components/layout/Select";
 import SquareButton from "frontend/components/layout/SquareButton";
 import { usePlayers } from "frontend/context/players";
 import { trpc } from "frontend/utils/trpc-client";
+import { useMatches } from "pages/your-matches";
 import { useEffect, useState } from "react";
 
 type Props = {
   currentPlayer: Player | undefined;
-  refetchYourMatches: () => void;
-  refetchAllMatches: () => void;
   setCurrentPlayer: (player: Player) => void;
 };
 
 export default function CreateMatch({
   currentPlayer,
-  refetchYourMatches,
-  refetchAllMatches,
   setCurrentPlayer,
 }: Props) {
   const { ownedPlayers } = usePlayers();
+  const { refetchYourMatches, refetchAllMatches } = useMatches();
 
   // Get map data
   const { data: mapQuery, isLoading: isLoadingMapQuery } =

--- a/src/frontend/components/match/MatchCardSetup.tsx
+++ b/src/frontend/components/match/MatchCardSetup.tsx
@@ -1,5 +1,6 @@
 import type { Match, Player } from "@prisma/client";
 import { trpc } from "frontend/utils/trpc-client";
+import { useMatches } from "pages/your-matches";
 import { useState } from "react";
 import type { Army } from "shared/schemas/army";
 import { armySchema } from "shared/schemas/army";
@@ -43,6 +44,7 @@ export default function MatchCardSetup({
   const readyMatch = trpc.match.setReady.useMutation();
   const leaveMatch = trpc.match.leave.useMutation();
   const [showDropdown, setShowDropdown] = useState("")
+  const { refetchYourMatches, refetchAllMatches } = useMatches();
 
   if (inMatch) {
     return (<div className="@flex">
@@ -208,7 +210,8 @@ export default function MatchCardSetup({
                   setCurrentPlayerOptions((prevState) => {return {...prevState, ready: !readyStatus}})
                   
                   if (!readyStatus) {
-                    location.reload();
+                    refetchAllMatches();
+                    refetchYourMatches();
                   }
                 });
             }}
@@ -228,7 +231,8 @@ export default function MatchCardSetup({
                   playerId: playerID,
                 })
                 .then(() => {
-                    location.reload();
+                    refetchAllMatches();
+                    refetchYourMatches();
                 });
             }}
           >
@@ -255,7 +259,8 @@ export default function MatchCardSetup({
                 })
                 .then(() => {
                   //lets reload the page
-                  location.reload();
+                  refetchAllMatches();
+                  refetchYourMatches();
                 });
             }}
           >

--- a/src/pages/your-matches.tsx
+++ b/src/pages/your-matches.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-misused-promises */
 import { usePlayers } from "frontend/context/players";
 import { trpc } from "frontend/utils/trpc-client";
 import Head from "next/head";
@@ -6,6 +7,25 @@ import CreateMatch from "frontend/components/match/CreateMatch";
 import { ProtectPage } from "frontend/components/auth/ProtectPage";
 import SquareButton from "frontend/components/layout/SquareButton";
 import { useRouter } from "next/router";
+import { createContext, useContext } from "react";
+
+const matchesContext = createContext<{
+  refetchYourMatches: () => void; 
+  refetchAllMatches: () => void;
+} | undefined>(undefined);
+
+export const useMatches = () => {
+  const matches = useContext(matchesContext);
+
+  const refetchYourMatches = matches?.refetchYourMatches ? matches?.refetchYourMatches : () => {return};
+
+  const refetchAllMatches = matches?.refetchAllMatches ? matches?.refetchAllMatches : () => {return};
+  
+  return {
+    refetchYourMatches,
+    refetchAllMatches
+  };
+};
 
 export default function YourMatches() {
   const route = useRouter();
@@ -23,19 +43,19 @@ export default function YourMatches() {
   const { data: allMatchesQuery, refetch: refetchAllMatches } =
     trpc.match.getAll.useQuery({ pageNumber: 0 });
 
-  const joinableMatchesQuery = allMatchesQuery?.filter(
-    (match) =>
-      match.players.filter(
-        (player) => player.id == currentPlayer?.id || match.players.length == 2
-      ).length == 0
-  );
+    const joinableMatchesQuery = allMatchesQuery?.filter(
+      (match) =>
+        match.players.filter(
+          (player) => player.id == currentPlayer?.id || match.players.length == 2
+        ).length == 0
+    );
 
-  const spectatorMatches = allMatchesQuery?.filter(
-    (match) =>
-      match.players.filter(
-        (player) => player.id == currentPlayer?.id || match.players.length != 2
-      ).length == 0
-  );
+    const spectatorMatches = allMatchesQuery?.filter(
+      (match) =>
+        match.players.filter(
+          (player) => player.id == currentPlayer?.id || match.players.length != 2
+        ).length == 0
+    );
 
   return (
     <ProtectPage>
@@ -43,39 +63,44 @@ export default function YourMatches() {
         <title>Game Lobby | Wars World</title>
       </Head>
 
-      <div className="@h-full @w-full @mt-4 @mb-16 @grid @gap-10 @text-center">
-        {/* Temporal button for ease of access to leaderboard. */}
-        <div className="@absolute @right-12 @top-8 @h-16 @text-xl">
-          <SquareButton onClick={() => {void route.push("/leaderboard");} }>
-            <svg className="@fill-white" height="40" viewBox="0 -960 960 960" width="40">
-              <path d="M280-880h400v314q0 23-10 41t-28 29l-142 84 28 92h152l-124 88 48 152-124-94-124 94 48-152-124-88h152l28-92-142-84q-18-11-28-29t-10-41v-314Zm80 80v234l80 48v-282h-80Zm240 0h-80v282l80-48v-234ZM480-647Zm-40-12Zm80 0Z"/>
-            </svg>
-          </SquareButton>
+      <matchesContext.Provider
+      value={{
+        refetchYourMatches,
+        refetchAllMatches,
+      }}
+    >
+        <div className="@h-full @w-full @mt-4 @mb-16 @grid @gap-10 @text-center">
+          {/* Temporal button for ease of access to leaderboard. */}
+          <div className="@absolute @right-12 @top-8 @h-16 @text-xl">
+            <SquareButton onClick={() => {void route.push("/leaderboard");} }>
+              <svg className="@fill-white" height="40" viewBox="0 -960 960 960" width="40">
+                <path d="M280-880h400v314q0 23-10 41t-28 29l-142 84 28 92h152l-124 88 48 152-124-94-124 94 48-152-124-88h152l28-92-142-84q-18-11-28-29t-10-41v-314Zm80 80v234l80 48v-282h-80Zm240 0h-80v282l80-48v-234ZM480-647Zm-40-12Zm80 0Z"/>
+              </svg>
+            </SquareButton>
+          </div>
+          <CreateMatch
+            currentPlayer={currentPlayer}
+            setCurrentPlayer={setCurrentPlayer}
+          />
+          <MatchSection title="Your Matches" matches={yourMatchesQuery} inMatch />
+          <MatchSection
+            title="Join a match"
+            matches={joinableMatchesQuery}
+            description="Matches you can join."
+          />
+          <MatchSection
+            title="Spectate a Match"
+            matches={spectatorMatches}
+            description="Matches with two players (not you)."
+          />
+          <MatchSection
+            jump="completedGames"
+            title="Completed games"
+            matches={undefined}
+            description="Work is progress..."
+          />
         </div>
-        <CreateMatch
-          refetchYourMatches={refetchYourMatches}
-          refetchAllMatches={refetchAllMatches}
-          currentPlayer={currentPlayer}
-          setCurrentPlayer={setCurrentPlayer}
-        />
-        <MatchSection title="Your Matches" matches={yourMatchesQuery} inMatch />
-        <MatchSection
-          title="Join a match"
-          matches={joinableMatchesQuery}
-          description="Matches you can join."
-        />
-        <MatchSection
-          title="Spectate a Match"
-          matches={spectatorMatches}
-          description="Matches with two players (not you)."
-        />
-        <MatchSection
-          jump="completedGames"
-          title="Completed games"
-          matches={undefined}
-          description="Work is progress..."
-        />
-      </div>
+      </matchesContext.Provider>
     </ProtectPage>
   );
 }

--- a/src/pages/your-matches.tsx
+++ b/src/pages/your-matches.tsx
@@ -43,19 +43,19 @@ export default function YourMatches() {
   const { data: allMatchesQuery, refetch: refetchAllMatches } =
     trpc.match.getAll.useQuery({ pageNumber: 0 });
 
-    const joinableMatchesQuery = allMatchesQuery?.filter(
-      (match) =>
-        match.players.filter(
-          (player) => player.id == currentPlayer?.id || match.players.length == 2
-        ).length == 0
-    );
+  const joinableMatchesQuery = allMatchesQuery?.filter(
+    (match) =>
+      match.players.filter(
+        (player) => player.id == currentPlayer?.id || match.players.length == 2
+      ).length == 0
+  );
 
-    const spectatorMatches = allMatchesQuery?.filter(
-      (match) =>
-        match.players.filter(
-          (player) => player.id == currentPlayer?.id || match.players.length != 2
-        ).length == 0
-    );
+  const spectatorMatches = allMatchesQuery?.filter(
+    (match) =>
+      match.players.filter(
+        (player) => player.id == currentPlayer?.id || match.players.length != 2
+      ).length == 0
+  );
 
   return (
     <ProtectPage>


### PR DESCRIPTION
Closes #214 

This is done so that refetchYourMatches and refetchAllMatches can be called way down the component tree.

The result of this allows us to join, create, and leave games without having to reload the entire page.