### PR TITLE
Refetching matches in your-matches is now done by invalidation

### DIFF
--- a/src/frontend/components/match/CreateMatch.tsx
+++ b/src/frontend/components/match/CreateMatch.tsx
@@ -4,7 +4,6 @@ import Select from "frontend/components/layout/Select";
 import SquareButton from "frontend/components/layout/SquareButton";
 import { usePlayers } from "frontend/context/players";
 import { trpc } from "frontend/utils/trpc-client";
-import { useMatches } from "pages/your-matches";
 import { useEffect, useState } from "react";
 
 type Props = {
@@ -17,7 +16,7 @@ export default function CreateMatch({
   setCurrentPlayer,
 }: Props) {
   const { ownedPlayers } = usePlayers();
-  const { refetchYourMatches, refetchAllMatches } = useMatches();
+  const utils = trpc.useUtils();
 
   // Get map data
   const { data: mapQuery, isLoading: isLoadingMapQuery } =
@@ -31,7 +30,11 @@ export default function CreateMatch({
       },
     });
   const [currentMapId, setCurrentMapId] = useState<string>();
-  const createMatchMutation = trpc.match.create.useMutation();
+  const createMatchMutation = trpc.match.create.useMutation({
+    onSuccess() {
+      void utils.match.invalidate()
+    }
+  });
 
   // Select Logic
   const players: SelectOption[] = [];
@@ -80,9 +83,6 @@ export default function CreateMatch({
       mapId: currentMapId,
       playerId: currentPlayer.id
     });
-
-    refetchAllMatches();
-    refetchYourMatches();
   };
 
   const selectPlayerHandler = (o: SelectOption | undefined) => {
@@ -97,8 +97,7 @@ export default function CreateMatch({
       setCurrentPlayer(newCurrentPlayer);
     }
     
-    refetchAllMatches();
-    refetchYourMatches();
+    void utils.match.invalidate()
   };
 
   const selectMapHandler = (o: SelectOption | undefined) => {

--- a/src/frontend/components/match/MatchCardSetup.tsx
+++ b/src/frontend/components/match/MatchCardSetup.tsx
@@ -1,6 +1,5 @@
 import type { Match, Player } from "@prisma/client";
 import { trpc } from "frontend/utils/trpc-client";
-import { useMatches } from "pages/your-matches";
 import { useState } from "react";
 import type { Army } from "shared/schemas/army";
 import { armySchema } from "shared/schemas/army";
@@ -39,12 +38,26 @@ export default function MatchCardSetup({
   setSelectedOptions,
   maxNumberOfPlayers
 }: matchData) {
+  const utils = trpc.useUtils();
   const switchOptions = trpc.match.switchOptions.useMutation();
-  const joinMatch = trpc.match.join.useMutation();
-  const readyMatch = trpc.match.setReady.useMutation();
-  const leaveMatch = trpc.match.leave.useMutation();
+
+  const joinMatch = trpc.match.join.useMutation({
+    onSuccess() {
+      void utils.match.invalidate()
+    },
+  });
+  const readyMatch = trpc.match.setReady.useMutation({
+    onSuccess() {
+      void utils.match.invalidate()
+    },
+  });
+  const leaveMatch = trpc.match.leave.useMutation({
+    onSuccess() {
+      void utils.match.invalidate()
+    },
+  });
+
   const [showDropdown, setShowDropdown] = useState("")
-  const { refetchYourMatches, refetchAllMatches } = useMatches();
 
   if (inMatch) {
     return (<div className="@flex">
@@ -208,11 +221,6 @@ export default function MatchCardSetup({
                 })
                 .then(() => {
                   setCurrentPlayerOptions((prevState) => {return {...prevState, ready: !readyStatus}})
-                  
-                  if (!readyStatus) {
-                    refetchAllMatches();
-                    refetchYourMatches();
-                  }
                 });
             }}
           >
@@ -230,10 +238,6 @@ export default function MatchCardSetup({
                   matchId: matchID,
                   playerId: playerID,
                 })
-                .then(() => {
-                    refetchAllMatches();
-                    refetchYourMatches();
-                });
             }}
           >
             Leave
@@ -257,11 +261,6 @@ export default function MatchCardSetup({
                   playerSlot: null,
                   selectedCO: {name: "sami", version: "AW2" }
                 })
-                .then(() => {
-                  //lets reload the page
-                  refetchAllMatches();
-                  refetchYourMatches();
-                });
             }}
           >
             Join Game

--- a/src/pages/your-matches.tsx
+++ b/src/pages/your-matches.tsx
@@ -7,32 +7,13 @@ import CreateMatch from "frontend/components/match/CreateMatch";
 import { ProtectPage } from "frontend/components/auth/ProtectPage";
 import SquareButton from "frontend/components/layout/SquareButton";
 import { useRouter } from "next/router";
-import { createContext, useContext } from "react";
-
-const matchesContext = createContext<{
-  refetchYourMatches: () => void; 
-  refetchAllMatches: () => void;
-} | undefined>(undefined);
-
-export const useMatches = () => {
-  const matches = useContext(matchesContext);
-
-  const refetchYourMatches = matches?.refetchYourMatches ? matches?.refetchYourMatches : () => {return};
-
-  const refetchAllMatches = matches?.refetchAllMatches ? matches?.refetchAllMatches : () => {return};
-  
-  return {
-    refetchYourMatches,
-    refetchAllMatches
-  };
-};
 
 export default function YourMatches() {
   const route = useRouter();
   const { currentPlayer, setCurrentPlayer } = usePlayers();
 
   // Get and make your, all, joinable, and spectator matches
-  const { data: yourMatchesQuery, refetch: refetchYourMatches } =
+  const { data: yourMatchesQuery } =
     trpc.match.getPlayerMatches.useQuery(
       { playerId: currentPlayer?.id ?? "" },
       {
@@ -40,7 +21,7 @@ export default function YourMatches() {
       }
     );
 
-  const { data: allMatchesQuery, refetch: refetchAllMatches } =
+  const { data: allMatchesQuery } =
     trpc.match.getAll.useQuery({ pageNumber: 0 });
 
   const joinableMatchesQuery = allMatchesQuery?.filter(
@@ -63,44 +44,37 @@ export default function YourMatches() {
         <title>Game Lobby | Wars World</title>
       </Head>
 
-      <matchesContext.Provider
-      value={{
-        refetchYourMatches,
-        refetchAllMatches,
-      }}
-    >
-        <div className="@h-full @w-full @mt-4 @mb-16 @grid @gap-10 @text-center">
-          {/* Temporal button for ease of access to leaderboard. */}
-          <div className="@absolute @right-12 @top-8 @h-16 @text-xl">
-            <SquareButton onClick={() => {void route.push("/leaderboard");} }>
-              <svg className="@fill-white" height="40" viewBox="0 -960 960 960" width="40">
-                <path d="M280-880h400v314q0 23-10 41t-28 29l-142 84 28 92h152l-124 88 48 152-124-94-124 94 48-152-124-88h152l28-92-142-84q-18-11-28-29t-10-41v-314Zm80 80v234l80 48v-282h-80Zm240 0h-80v282l80-48v-234ZM480-647Zm-40-12Zm80 0Z"/>
-              </svg>
-            </SquareButton>
-          </div>
-          <CreateMatch
-            currentPlayer={currentPlayer}
-            setCurrentPlayer={setCurrentPlayer}
-          />
-          <MatchSection title="Your Matches" matches={yourMatchesQuery} inMatch />
-          <MatchSection
-            title="Join a match"
-            matches={joinableMatchesQuery}
-            description="Matches you can join."
-          />
-          <MatchSection
-            title="Spectate a Match"
-            matches={spectatorMatches}
-            description="Matches with two players (not you)."
-          />
-          <MatchSection
-            jump="completedGames"
-            title="Completed games"
-            matches={undefined}
-            description="Work is progress..."
-          />
+      <div className="@h-full @w-full @mt-4 @mb-16 @grid @gap-10 @text-center">
+        {/* Temporal button for ease of access to leaderboard. */}
+        <div className="@absolute @right-12 @top-8 @h-16 @text-xl">
+          <SquareButton onClick={() => {void route.push("/leaderboard");} }>
+            <svg className="@fill-white" height="40" viewBox="0 -960 960 960" width="40">
+              <path d="M280-880h400v314q0 23-10 41t-28 29l-142 84 28 92h152l-124 88 48 152-124-94-124 94 48-152-124-88h152l28-92-142-84q-18-11-28-29t-10-41v-314Zm80 80v234l80 48v-282h-80Zm240 0h-80v282l80-48v-234ZM480-647Zm-40-12Zm80 0Z"/>
+            </svg>
+          </SquareButton>
         </div>
-      </matchesContext.Provider>
+        <CreateMatch
+          currentPlayer={currentPlayer}
+          setCurrentPlayer={setCurrentPlayer}
+        />
+        <MatchSection title="Your Matches" matches={yourMatchesQuery} inMatch />
+        <MatchSection
+          title="Join a match"
+          matches={joinableMatchesQuery}
+          description="Matches you can join."
+        />
+        <MatchSection
+          title="Spectate a Match"
+          matches={spectatorMatches}
+          description="Matches with two players (not you)."
+        />
+        <MatchSection
+          jump="completedGames"
+          title="Completed games"
+          matches={undefined}
+          description="Work is progress..."
+        />
+      </div>
     </ProtectPage>
   );
 }


### PR DESCRIPTION
Refetching matches before this was done by explicitly calling the refetch function provided by getAll and getPlayerMatches. Those refetch functions were passed into a context where subcomponents of your-matches will be able to use them. The reason for this was to prevent prop drilling the refetch functions from your-matches all the way down to MatchCardSetup.

However, function advised that there was a simpler implementation. By invalidating the queries, the the getAll and getPlayerMatches queries would automatically refetch. Thus, removing the need for creating a context and simplifying code. (thanks function)