### PR TITLE
Finished implementation of in game chat boxes (#223)

### DIFF
--- a/src/frontend/components/ChatBox.tsx
+++ b/src/frontend/components/ChatBox.tsx
@@ -1,0 +1,86 @@
+import { trpc } from "frontend/utils/trpc-client";
+import { useEffect, useState } from "react";
+import type { FrontendChatMessage } from "shared/types/component-data";
+import SquareButton from "./layout/SquareButton";
+import FormInput from "./layout/forms/FormInput";
+
+type Props = {
+  chat?: FrontendChatMessage[] | null;
+  matchId: string;
+  currentPlayerId?: string;
+};
+
+function formatDate(date: Date) {
+  return date.toLocaleTimeString().substring(0, date.toLocaleTimeString().length - 6);
+}
+
+export function ChatBox({ chat, matchId, currentPlayerId }: Props) {
+  const [message, setMessage] = useState("");
+  const [isVisisble, setIsVisible] = useState(false);
+
+  const chatMutation = trpc.action.sendChatMessage.useMutation();
+
+  // Force the chat history to go to bottom
+  useEffect(() => {
+    const objDiv = document.getElementById("chatHistory");
+    objDiv!.scrollTop = objDiv!.scrollHeight;
+  }, [chat]);
+
+  return (
+    <section
+      className={`@fixed ${
+        isVisisble ? "@right-0" : "@right-[-360px]"
+      } @w-[360px] @h-[500px] @bg-bg-tertiary @border-4 @border-black @p-2 @flex @flex-col`}
+    >
+      <div
+        className="@absolute @h-[100px] @w-[30px] @left-[-30px] @bg-bg-tertiary @border-4 @border-black @cursor-pointer"
+        onClick={() => {
+          setIsVisible((prev) => !prev);
+        }}
+      >
+        {`>>\n`}
+        {`>>\n`}
+        {`>>\n`}
+        {`>>\n`}
+      </div>
+      <div className="@flex @justify-center @mb-2">
+        <p className="@w-2/3 @text-center">Live Chat</p>
+      </div>
+      <div className="@basis-auto @grow @shrink">
+        {/* Chat History */}
+        <div id="chatHistory" className="@h-[300px] @bg-black/50 @overflow-auto @p-2">
+          {chat?.map(({ createdAt, name, content }, index) => (
+            <div className="@flex" key={index}>
+              <div className="@text-white/30 @min-w-9 @text-right @mr-1">
+                {formatDate(createdAt)}
+              </div>
+              <div>
+                <span className="@text-secondary">{name}</span>:<span> {content}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          void chatMutation.mutateAsync({
+            matchId: matchId,
+            playerId: currentPlayerId!,
+            message: message,
+          });
+          setMessage("");
+        }}
+      >
+        <FormInput
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          type="text"
+        />
+        <div className="@self-end @my-2 @ml-auto @w-fit">
+          <SquareButton type="submit">Chat</SquareButton>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/src/frontend/components/layout/forms/FormInput.tsx
+++ b/src/frontend/components/layout/forms/FormInput.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEventHandler } from "react";
 
 type Props = {
-  text: string;
+  text?: string;
   className?: string;
   isError?: boolean;
   errorMessage?: string;
@@ -24,9 +24,11 @@ export default function FormInput({
   return (
     <>
       <div className={className}>
-        <label htmlFor={id ?? ""} className="@text-xl smallscreen:@text-2xl @text-white">
-          {text}
-        </label>
+        {text ?? (
+          <label htmlFor={id ?? ""} className="@text-xl smallscreen:@text-2xl @text-white">
+            {text}
+          </label>
+        )}
         <input
           id={id ?? ""}
           name={id ?? ""}

--- a/src/frontend/components/layout/forms/TextAreaInput.tsx
+++ b/src/frontend/components/layout/forms/TextAreaInput.tsx
@@ -10,6 +10,7 @@ type Props = {
   value?: string | number | readonly string[];
   id?: string;
   onChange?: ChangeEventHandler<HTMLTextAreaElement>;
+  textAreaStyling?: string;
 };
 
 export default function TextAreaInput({
@@ -20,6 +21,7 @@ export default function TextAreaInput({
   isError,
   errorMessage,
   onChange,
+  textAreaStyling,
   className,
   height,
 }: Props) {
@@ -32,7 +34,7 @@ export default function TextAreaInput({
         <textarea
           className={`@mt-2 @w-full @text-white @p-4 @text-xl smallscreen:@text-2xl @border-[2.5px] @rounded-2xl @bg-black/50 ${
             isError == true ? "@border-orange-star" : "@border-primary"
-          }`}
+          } ${textAreaStyling}`}
           name={name}
           style={{ height }}
           placeholder="Write here... "

--- a/src/shared/types/component-data.ts
+++ b/src/shared/types/component-data.ts
@@ -9,4 +9,10 @@ export type FrontendMatch = {
   turn: number;
 };
 
+export type FrontendChatMessage = {
+  createdAt: Date;
+  name: string;
+  content: string;
+};
+
 export type MapBasic = Pick<WWMap, "id" | "name" | "numberOfPlayers">;

--- a/src/shared/types/events.ts
+++ b/src/shared/types/events.ts
@@ -16,11 +16,12 @@ import type {
 } from "shared/schemas/action";
 import type { Army } from "shared/schemas/army";
 import type { COID } from "shared/schemas/co";
+import type { PlayerSlot } from "shared/schemas/player-slot";
 import type { Position } from "shared/schemas/position";
 import type { WWUnit } from "shared/schemas/unit";
 import type { Weather } from "shared/schemas/weather";
+import type { FrontendChatMessage } from "./component-data";
 import type { CapturableTile } from "./server-match-state";
-import type { PlayerSlot } from "shared/schemas/player-slot";
 
 /** player slot 0 implicity starts */
 export type MatchStartEvent = {
@@ -147,6 +148,11 @@ export type EmittableMoveEvent = Omit<MoveEvent, "subEvent"> &
     appearingUnit?: WWUnit;
   };
 
+// Chat Messages Events
+export type ChatMessageEvent = {
+  type: "chatMessage";
+} & FrontendChatMessage;
+
 export type EmittableEvent = (
   | MatchStartEvent
   | EmittableMoveEvent
@@ -157,6 +163,7 @@ export type EmittableEvent = (
   | BuildEvent
   | DeleteEvent
   | MatchEndEvent
+  | ChatMessageEvent
 ) &
   WithDiscoveries;
 


### PR DESCRIPTION
Within each ongoing match, a fixed chat box now appears on the right side. The messages are sent and received in real time using the same subscription hook for match events.

Notably, the chat messages are not stored in local memory in the server. Every time a player sends a message, it gets created in the database and then an event is broadcasted. I wanted to keep match-wrapper as simple as it can be.