### PR TITLE
Address TypeScript/ESLINT errors and a syntax error

### DIFF
--- a/src/components/client-only/MatchLoader.tsx
+++ b/src/components/client-only/MatchLoader.tsx
@@ -56,7 +56,7 @@ export function MatchLoader({ matchId, playerId, spritesheetDataByArmy }: Props)
   // Add useEffect to trigger refetch when turn changes
   useEffect(() => {
     fullMatchQuery.refetch();
-  }, [turn]);
+  }, [turn, fullMatchQuery]);
 
   if (fullMatchQuery.isError || spriteSheetQuery.isError) {
     return <p>error {":("}</p>;

--- a/src/components/client-only/MatchLoader.tsx
+++ b/src/components/client-only/MatchLoader.tsx
@@ -55,7 +55,7 @@ export function MatchLoader({ matchId, playerId, spritesheetDataByArmy }: Props)
 
   // Add useEffect to trigger refetch when turn changes
   useEffect(() => {
-    fullMatchQuery.refetch();
+    void fullMatchQuery.refetch();
   }, [turn, fullMatchQuery]);
 
   if (fullMatchQuery.isError || spriteSheetQuery.isError) {

--- a/src/components/client-only/MatchRenderer.tsx
+++ b/src/components/client-only/MatchRenderer.tsx
@@ -19,7 +19,7 @@ type Props = {
   player: PlayerInMatchWrapper;
   spriteSheets: LoadedSpriteSheet;
   turn: boolean;
-  setTurn: any;
+  setTurn: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const baseTileSize = 16;
@@ -30,7 +30,8 @@ export const mapBorder = baseTileSize / 2;
 export function MatchRenderer({ match, player, spriteSheets, turn, setTurn }: Props) {
   const [eventTrigger, setEventTrigger] = useState(0);
   useEffect(() => {
-    setTurn(match.getCurrentTurnPlayer().data.id === player.data.id);
+    const isPlayerTurn = match.getCurrentTurnPlayer().data.id === player.data.id;
+    setTurn(isPlayerTurn);
   }, []);
 
   const { pixiCanvasRef } = usePixi(match, spriteSheets, player);

--- a/src/components/client-only/MatchRenderer.tsx
+++ b/src/components/client-only/MatchRenderer.tsx
@@ -32,7 +32,7 @@ export function MatchRenderer({ match, player, spriteSheets, turn, setTurn }: Pr
   useEffect(() => {
     const isPlayerTurn = match.getCurrentTurnPlayer().data.id === player.data.id;
     setTurn(isPlayerTurn);
-  }, []);
+  }, [match, player.data.id, setTurn]);
 
   const { pixiCanvasRef } = usePixi(match, spriteSheets, player);
 

--- a/src/components/client-only/use-pixi.ts
+++ b/src/components/client-only/use-pixi.ts
@@ -40,14 +40,6 @@ export const usePixi = (
 
   const { actionMutation } = trpcActions();
 
-  const sendAction = async (action: MainAction) => {
-    await actionMutation.mutateAsync({
-      playerId: player.data.id,
-      matchId: match.id,
-      ...action,
-    });
-  };
-
   useEffect(() => {
     const app = new Application({
       view: pixiCanvasRef.current ?? undefined,
@@ -57,6 +49,14 @@ export const usePixi = (
       width: match.map.width * renderedTileSize + renderedTileSize,
       height: match.map.height * renderedTileSize + renderedTileSize,
     });
+
+    const sendAction = async (action: MainAction) => {
+      await actionMutation.mutateAsync({
+        playerId: player.data.id,
+        matchId: match.id,
+        ...action,
+      });
+    };
 
     const onTileClick = async (pos: Position) => {
       if (
@@ -125,7 +125,7 @@ export const usePixi = (
         tile.off("pointerenter");
       }
     };
-  }, [actionMutation, match, player, spriteSheets, sendAction]);
+  }, [actionMutation, match, player, spriteSheets]);
 
   return {
     pixiCanvasRef,

--- a/src/components/client-only/use-pixi.ts
+++ b/src/components/client-only/use-pixi.ts
@@ -125,7 +125,7 @@ export const usePixi = (
         tile.off("pointerenter");
       }
     };
-  }, [actionMutation, match, player, spriteSheets]);
+  }, [actionMutation, match, player, spriteSheets, sendAction]);
 
   return {
     pixiCanvasRef,

--- a/src/frontend/components/calculator/COCalculator.tsx
+++ b/src/frontend/components/calculator/COCalculator.tsx
@@ -10,7 +10,7 @@ type Props = {
   coPower: boolean;
 };
 
-export default function COCalculator({ co, coPower, capture, commtower, gold }: Props) {
+export default function COCalculator({ co, _coPower, capture, commtower, gold }: Props) {
   return (
     <>
       <div className="@col-span-6 @flex @bg-bg-tertiary @justify-between @align-middle @items-center ">

--- a/src/frontend/components/calculator/Calculator.tsx
+++ b/src/frontend/components/calculator/Calculator.tsx
@@ -1,5 +1,5 @@
 import COCalculator from "./COCalculator";
-import { CO } from "../../../shared/schemas/co";
+// import { CO } from "../../../shared/schemas/co"; // TODO: unused import
 import type { PlayerInMatch } from "shared/types/server-match-state";
 
 type Props = {

--- a/src/pixi/buildUnitMenu.ts
+++ b/src/pixi/buildUnitMenu.ts
@@ -160,7 +160,8 @@ export const buildUnitMenu = (
   return menuContainer;
 };
 
-const createCaptureOption = (match: MatchWrapper, onCapture: () => void): Container => {
+// TODO: unused yet
+const _createCaptureOption = (match: MatchWrapper, onCapture: () => void): Container => {
   const menuElement = new Container();
   menuElement.eventMode = "static";
   //TODO: missing action icons

--- a/src/pixi/handleClick.ts
+++ b/src/pixi/handleClick.ts
@@ -233,7 +233,7 @@ export const handleHover = async (
   unitRangeShowRef: MutableRefObject<"attack" | "movement" | "vision">,
   pathRef: MutableRefObject<Position[] | null>,
   spriteSheets: LoadedSpriteSheet,
-  sendAction: (action: MainAction) => Promise<void>,
+  _sendAction: (action: MainAction) => Promise<void>, // TODO: unused yet
 ) => {
   await Assets.load("/aw2Font.fnt");
 

--- a/src/pixi/interactiveTileFunctions.ts
+++ b/src/pixi/interactiveTileFunctions.ts
@@ -88,6 +88,8 @@ export const getBattleForecast = (
 };
 
 export const readyUnitClickedAttackableTile = (
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  // TODO: unused yet
   confirmation: boolean, //only sends action if true
   match: MatchWrapper,
   attacker: UnitWrapper,
@@ -102,6 +104,8 @@ export const readyUnitClickedAttackableTile = (
 };
 
 export const readyUnitClickedAccessibleTile = (
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  // TODO: unused yet
   match: MatchWrapper,
   unit: UnitWrapper,
   position: Position,

--- a/src/pixi/renderAttackTiles.ts
+++ b/src/pixi/renderAttackTiles.ts
@@ -2,7 +2,7 @@ import type { DisplayObject } from "pixi.js";
 import { BitmapText, Container, Sprite, Texture } from "pixi.js";
 import type { MutableRefObject } from "react";
 import type { MainAction } from "shared/schemas/action";
-import { baseTileSize, renderedTileSize } from "../components/client-only/MatchRenderer";
+import { /*baseTileSize,*/ renderedTileSize } from "../components/client-only/MatchRenderer";
 import type { Position } from "../shared/schemas/position";
 import type { MatchWrapper } from "../shared/wrappers/match";
 import type { PlayerInMatchWrapper } from "../shared/wrappers/player-in-match";

--- a/src/pixi/renderPlayerInfoCard.ts
+++ b/src/pixi/renderPlayerInfoCard.ts
@@ -26,5 +26,5 @@ export const renderPlayerInfoCard = (match: MatchWrapper, playerSlot: number) =>
 
   const units = player.getUnits();
   const unitCount = units.length;
-  const unitValue = //sum of unit.getBuildCost() * unit.getVisualHP()/10
+  const unitValue = 0; // TODO: sum of unit.getBuildCost() * unit.getVisualHP()/10
 };

--- a/src/pixi/renderPlayerInfoCard.ts
+++ b/src/pixi/renderPlayerInfoCard.ts
@@ -1,6 +1,8 @@
 import { getCOProperties } from "shared/match-logic/co";
 import type { MatchWrapper } from "shared/wrappers/match";
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// TODO: unused yet
 export const renderPlayerInfoCard = (match: MatchWrapper, playerSlot: number) => {
   const player = match.getPlayerBySlot(playerSlot);
 

--- a/src/pixi/renderPlayerInfoCard.ts
+++ b/src/pixi/renderPlayerInfoCard.ts
@@ -1,5 +1,5 @@
 import { getCOProperties } from "shared/match-logic/co";
-import { MatchWrapper } from "shared/wrappers/match";
+import type { MatchWrapper } from "shared/wrappers/match";
 
 export const renderPlayerInfoCard = (match: MatchWrapper, playerSlot: number) => {
   const player = match.getPlayerBySlot(playerSlot);
@@ -9,8 +9,6 @@ export const renderPlayerInfoCard = (match: MatchWrapper, playerSlot: number) =>
   }
 
   const coId = player.data.coId;
-
-
 
   const currentPower = player.data.powerMeter;
   const startCost = player.getPowerStarCost();

--- a/src/pixi/renderUnits.ts
+++ b/src/pixi/renderUnits.ts
@@ -1,6 +1,6 @@
 import type { FrontendUnit } from "frontend/components/match/FrontendUnit";
 import type { ChangeableTileWithSprite } from "frontend/components/match/types";
-import { AnimatedSprite, Container } from "pixi.js";
+import { /* AnimatedSprite,*/ Container } from "pixi.js";
 import type { MatchWrapper } from "shared/wrappers/match";
 import type { LoadedSpriteSheet } from "./load-spritesheet";
 import { renderUnitSprite } from "./renderUnitSprite";

--- a/src/server/emitter/create-emitter.ts
+++ b/src/server/emitter/create-emitter.ts
@@ -11,7 +11,7 @@ export const createEmitter = <D extends { matchId: Match["id"] }>() => {
   //New update
   const listenerMap = new Map<Match["id"], Map<string, Listener[]>>();
 
-  const unsubscribe = (matchId: Match["id"], playerId: string, listenerToUnsub: Listener) => {
+  const unsubscribe = (matchId: Match["id"], playerId: string, _listenerToUnsub: Listener) => {
     listenerMap.get(matchId)?.delete(playerId);
   };
 

--- a/src/server/routers/action.ts
+++ b/src/server/routers/action.ts
@@ -20,7 +20,7 @@ import { updateMoveVision } from "../../shared/match-logic/events/handlers/move"
 export const actionRouter = router({
   send: playerInMatchBaseProcedure
     .input(mainActionSchema)
-    .mutation(async ({ input, ctx: { match, player } }) => {
+    .mutation(async ({ input, ctx: { match, _player } }) => {
       /**
        * EXTREMELY IMPORTANT! This order MUST be followed, otherwise some things may not have required information:
        * 1. Move action to event
@@ -57,7 +57,7 @@ export const actionRouter = router({
 
         /* 3. Sub action to event */
         // if there was a trap or join/load, the default subEvent is "wait".
-        const isJoinOrLoad = match.getUnit(getFinalPositionSafe(mainEvent.path)) !== undefined;
+        const _isJoinOrLoad = match.getUnit(getFinalPositionSafe(mainEvent.path)) !== undefined;
         //todo: isJoinorLoad doesnt really work, have to fix
 
         if (!mainEvent.trap /*&& !isJoinOrLoad*/) {

--- a/src/server/routers/match.ts
+++ b/src/server/routers/match.ts
@@ -36,7 +36,8 @@ export const matchRouter = router({
     ({ ctx: { currentPlayer } }) =>
       playerMatchIndex.getPlayerMatches(currentPlayer.id)?.map(matchToFrontend) ?? [],
   ),
-  full: matchBaseProcedure.query(({ ctx: { match, currentPlayer } }) => ({
+  // currentPlayer unused yet
+  full: matchBaseProcedure.query(({ ctx: { match, _currentPlayer } }) => ({
     id: match.id,
     leagueType: match.leagueType,
     changeableTiles: match.changeableTiles,

--- a/src/shared/match-logic/calculate-damage.ts
+++ b/src/shared/match-logic/calculate-damage.ts
@@ -8,7 +8,8 @@ import { getTerrainDefenseStars } from "./game-constants/terrain-properties";
 /** @returns 1-10, whole numbers */
 export const getVisualHPfromHP = (hp: number) => Math.ceil(hp / 10);
 
-const roundUpTo = (value: number, step: number) => {
+// unused yet
+const _roundUpTo = (value: number, step: number) => {
   const scalingFactor = 1 / step;
   return Math.ceil(value * scalingFactor) / scalingFactor;
 };

--- a/src/shared/match-logic/events/handlers/move.ts
+++ b/src/shared/match-logic/events/handlers/move.ts
@@ -60,7 +60,7 @@ export const moveActionToEvent: MainActionToEvent<MoveAction> = (match, action) 
       throw new DispatchableError("Cannot move to a desired position");
     }
 
-    if (result.path.find((pos) => isSamePosition(pos, position))) {
+    if (result.path.some((pos) => isSamePosition(pos, position))) {
       throw new DispatchableError("The given path passes through the same position twice");
     }
 

--- a/src/shared/match-logic/game-constants/version-properties.ts
+++ b/src/shared/match-logic/game-constants/version-properties.ts
@@ -151,7 +151,7 @@ const AWDSProperties: VersionProperties = {
 };
 
 // as proof of concept:
-const AWBWProperties: VersionProperties = {
+const _AWBWProperties: VersionProperties = {
   gameVersion: "AW2", // not accurate
   baseGoodLuck: 10,
   baseBadLuck: 0,

--- a/src/shared/wrappers/player-in-match.ts
+++ b/src/shared/wrappers/player-in-match.ts
@@ -11,12 +11,12 @@ import { UnitWrapper } from "./unit";
 //TODO: Band-aid fix from chatGPT, needs to be fixed down below
 
 // Type guard to check if the object is a UnitWrapper
-function isUnitWrapper(object: any): object is UnitWrapper {
+function isUnitWrapper(object: Tile | ChangeableTile | UnitWrapper): object is UnitWrapper {
   return "data" in object && "playerSlot" in object.data;
 }
 
 // Type guard to check if the object is a PropertyTile (or has playerSlot directly)
-function isPropertyTile(object: any): object is PropertyTile {
+function isPropertyTile(object: Tile | ChangeableTile | UnitWrapper): object is PropertyTile {
   return "playerSlot" in object;
 }
 


### PR DESCRIPTION
Fixes https://github.com/WarsWorld/WarsWorld/issues/238
This addresses a variety of ESLINT errors returned by npm run lint:fix, and one straight up syntax error (13ad92ee064acff2c1764431b9e386fd1fbcfe9a).

Some dependencies were missing and were added.
Some function code was moved to resolve unnecessary scope issues (4847b989e30578cae05c0e8f3acc527d083c6785)
There is a number of unused variables and imports that were marked as such. The `_` prefix suppresses warnings, and a TODO comment is added were fit.

Fixes are split in a different commit so this PR can be split in many if needed.