### PR TITLE
Fix mistyped shared alias in `tsconfig.json` breaking server builds

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "paths": {
-      "shared/*": ["/shared/*"]
+      "shared/*": ["shared/*"]
     },
     "target": "esnext",
 


### PR DESCRIPTION
Addresses a bug introduced in 3eb7370e4c740819d1aaf750b82b3249c7c5a3b3.
Closes https://github.com/WarsWorld/WarsWorld/issues/246.