### PR TITLE
Add `generate-spritesheets` utils with config and docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "build": "concurrently \"npm:build:*\"",
     "start": "cross-env NODE_ENV=production node dist/server/main-production.js",
     "redundant-code": "npx jscpd --ignore node_modules,dist,public,.next --reporters consoleFull .",
-    "update-depencencies": "npx npm-check-updates -i"
+    "update-depencencies": "npx npm-check-updates -i",
+    "install-utils": "npm install $(jq -r '.utilsDependencies | to_entries | .[] | \"\\(.key)@\\(.value)\"' package.json)"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"
@@ -59,6 +60,7 @@
     "remark": "^15.0.1",
     "remark-html": "^16.0.1",
     "sass": "^1.70.0",
+    "sharp": "^0.33.5",
     "superjson": "^2.2.1",
     "uuid": "^9.0.1",
     "ws": "^8.16.0",
@@ -90,5 +92,8 @@
     "tailwindcss": "^3.4.1",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3"
+  },
+  "utilsDependencies": {
+    "sharp": "^0.33.2"
   }
 }

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,18 @@
+## WarsWorld utils
+
+In this directory you will find miscellaneous standalone utilities.
+
+### Installing requirements
+
+Some utils have extra node dependencies documented in `package.json` under `"utilsDependencies"`. You can visualize them with
+
+```sh
+jq -r '.utilsDependencies' package.json
+```
+
+and you can install them automatically with
+
+```sh
+npm run install-utils
+```
+

--- a/utils/generate-spritesheets/.gitignore
+++ b/utils/generate-spritesheets/.gitignore
@@ -1,0 +1,3 @@
+AWBW-Replay-Player
+output
+*.js

--- a/utils/generate-spritesheets/README.md
+++ b/utils/generate-spritesheets/README.md
@@ -1,0 +1,35 @@
+## generate-spreadsheets
+
+This is a node.js script using sharp.js as a dependency, originally written by FunctionDJ. 
+
+This utility creates spritesheets with images sourced from [AWBW-Replay-Player](https://github.com/DeamonHunter/AWBW-Replay-Player/) by DeamonHunter (MIT License).
+
+### Prerequisites
+
+#### AWBW-Replay-Player/AWBWApp.Resources/Textures
+
+This utility hardcodes some paths and in particular expects you to have the [AWBW-Replay-Player](https://github.com/DeamonHunter/AWBW-Replay-Player/) in the same directory as the script, and in particular the textures in `AWBW-Replay-Player/AWBWApp.Resources/Textures`.
+
+To do this, you can run
+
+```sh
+# cd [PROJECT_ROOT]/utils/generate-spritesheets
+git clone https://github.com/DeamonHunter/AWBW-Replay-Player/
+```
+
+#### output dir
+
+You also need to set up an `output` dir:
+
+```sh
+mkdir output
+```
+
+### Running `main.ts`
+
+Use something akin to
+
+```sh
+node --loader ts-node/esm main.ts
+```
+

--- a/utils/generate-spritesheets/main.ts
+++ b/utils/generate-spritesheets/main.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ISpritesheetData, ISpritesheetFrameData } from "pixi.js";
+import sharp from "sharp";
+
+const __filename = fileURLToPath(import.meta.url);
+
+const __dirname = path.dirname(__filename);
+
+const texturePath = path.resolve(__dirname, "AWBW-Replay-Player/AWBWApp.Resources/Textures");
+
+const nations = await fs.readdir(path.resolve(texturePath, "Units"));
+
+// const [someNation] = nations;
+
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
+nations.forEach(async (nation) => {
+  const spriteSourceType = ["Map/AW2", "Units"] as const;
+
+  const allSprites: { source: (typeof spriteSourceType)[number]; name: string }[] = [];
+
+  for (const source of spriteSourceType) {
+    const sprites = await fs.readdir(path.resolve(texturePath, source, nation));
+    allSprites.push(...sprites.map((s) => ({ source, name: s })));
+  }
+
+  const squareRoot = Math.sqrt(allSprites.length);
+  const columns = Math.round(squareRoot);
+
+  if (columns === 0) {
+    console.error("no input - spritesheet would be empty");
+    process.exit(1);
+  }
+
+  const rows = Math.ceil(allSprites.length / columns);
+
+  let cellWidth = 0;
+  let cellHeight = 0;
+
+  for (const sprite of allSprites) {
+    const { width, height } = await sharp(
+      path.resolve(texturePath, sprite.source, nation, sprite.name),
+    ).metadata();
+
+    cellWidth = Math.max(cellWidth, width!);
+    cellHeight = Math.max(cellHeight, height!);
+  }
+
+  const spriteSheetImage = sharp({
+    create: {
+      width: columns * cellWidth,
+      height: rows * cellHeight,
+      channels: 4,
+      background: {
+        r: 0,
+        g: 0,
+        b: 0,
+        alpha: 0,
+      },
+    },
+  });
+
+  const frames: Record<string, ISpritesheetFrameData> = {};
+
+  for (let i = 0; i < allSprites.toSorted((a, b) => (a.name < b.name ? -1 : 1)).length; i++) {
+    const sprite = allSprites[i];
+    const metadata = await sharp(
+      path.resolve(texturePath, sprite.source, nation, sprite.name),
+    ).metadata();
+
+    frames[(sprite.source === "Map/AW2" ? "map" : "unit") + "." + sprite.name] = {
+      frame: {
+        x: (i % columns) * cellWidth,
+        y: Math.floor(i / rows) * cellHeight,
+        w: metadata.width!,
+        h: metadata.height!,
+      },
+    };
+  }
+
+  const animationFrameRegex = /^(.*)-\d+\.png$/i;
+
+  const animationKeys = new Set(
+    allSprites
+      .map((sprite) => {
+        const result = animationFrameRegex.exec(sprite.name);
+
+        if (result?.[1] !== undefined) {
+          return {
+            source: sprite.source,
+            name: result[1],
+          };
+        } else {
+          return null;
+        }
+      })
+      .filter((animationKey) => animationKey !== null) as { source: string; name: string }[],
+  );
+
+  const animations: Record<string, string[]> = {};
+
+  for (const { source, name } of animationKeys) {
+    animations[(source === "Units" ? "unit" : "map") + "." + name] = allSprites
+      .filter((sprite) => sprite.name.startsWith(name))
+      .map((sprite) => (sprite.source === "Units" ? "unit" : "map") + "." + sprite.name)
+      .toSorted();
+  }
+
+  const spriteSheetData: ISpritesheetData = {
+    meta: {
+      scale: 1,
+    },
+    frames,
+    animations,
+  };
+
+  await spriteSheetImage
+    .composite(
+      Object.entries(frames).map(([key, { frame }]) => {
+        const [source, name] = key.split(".");
+
+        let sourcePath = "";
+
+        if (source === "map") {
+          sourcePath = "Map/AW2";
+        } else if (source === "unit") {
+          sourcePath = "Units";
+        } else {
+          throw new Error(`can't handle this frame key for compositing the file: ${source}`);
+        }
+
+        return {
+          input: path.resolve(texturePath, sourcePath, nation, name + ".png"),
+          left: frame.x,
+          top: frame.y,
+        };
+      }),
+    )
+    .toFile(path.resolve(__dirname, `output/${nation}.webp`));
+
+  await fs.writeFile(
+    path.resolve(__dirname, `output/${nation}.json`),
+    JSON.stringify(spriteSheetData, null, 2),
+  );
+});


### PR DESCRIPTION
This PR
- cherry-picks the generate-spritesheets script by @FunctionDJ from https://github.com/WarsWorld/WarsWorld/commit/86e325f7e5dd79dcc34cd67eac779e324393ad5f (branch generate-spritesheets)
- moves it into an `utils` subdirectory, adds documentation and a script in package.json (819e169dcffb7e85943c49fa33878cc848cda710)