### PR TITLE
fix: Lints and build on CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 # https://www.typescriptlang.org/tsconfig#tsBuildInfoFile
 tsconfig.tsbuildinfo
 prisma/migrations/20230510171142_amogus/migration.sql
+
+.ai
+.omc

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,10 @@
 node_modules/
 .next/
 dist/
+
+# Tool/IDE state, not source. Left unformatted these fail `npm run lint` locally for reasons that
+# have nothing to do with the code under review.
+.moonlight/
+.moonlight-local/
+.ai/
+.omc/

--- a/src/pixi/in-game-menus/unloadSubactionMenu.ts
+++ b/src/pixi/in-game-menus/unloadSubactionMenu.ts
@@ -165,11 +165,15 @@ export const createUnloadMenu = (
   };
 
   if (unloadPositions1 !== undefined && unloadPositions1.length > 0) {
+    // Captured so the narrowing survives into the handler: `unloadPositions1` is a `let`, and TS
+    // discards the enclosing guard's narrowing inside a callback.
+    const positions1 = unloadPositions1;
+
     menuElements[0].on("pointerdown", () => {
       const unloadTilesContainer = new Container();
       unloadTilesContainer.name = "unloadUnitsBox";
 
-      for (const unloadPos of unloadPositions1) {
+      for (const unloadPos of positions1) {
         const unloadTile = tileConstructor(unloadPos, "#43d9e4");
         unloadTile.eventMode = "static";
 
@@ -197,12 +201,15 @@ export const createUnloadMenu = (
   }
 
   if (unloadPositions2 !== undefined && unloadPositions2.length > 0) {
+    // Captured for the same reason as `positions1` above.
+    const positions2 = unloadPositions2;
     const meIndex = unloadPositions1 === undefined ? 0 : 1; //if unit1 wasnt unloadable, the index will be 0
+
     menuElements[meIndex].on("pointerdown", () => {
       const unloadTilesContainer = new Container();
       unloadTilesContainer.name = "unloadUnitsBox";
 
-      for (const unloadPos of unloadPositions2) {
+      for (const unloadPos of positions2) {
         const unloadTile = tileConstructor(unloadPos, "#43d9e4");
         unloadTile.eventMode = "static";
 

--- a/utils/generate-spritesheets/main.ts
+++ b/utils/generate-spritesheets/main.ts
@@ -34,14 +34,13 @@ type Sprite = {
   name: string;
 };
 
-// _eslint-disable-next-line @typescript-eslint/no-misused-promises
-nations.forEach(async (nation) => {
+for (const nation of nations) {
   // fetch sprites
   const allSprites = await getAllSprites(nation);
   // generate frames and spritesheet image
   const { frames, spriteSheetImage } = await genFramesAndSpriteSheetImage(nation, allSprites);
   // fetch animations map
-  const animations = await fetchAnimations(allSprites, frames);
+  const animations = fetchAnimations(allSprites);
 
   // write WebP files
   await spriteSheetImage
@@ -72,7 +71,7 @@ nations.forEach(async (nation) => {
     path.resolve(__dirname, outputPath, `${nation}.json`),
     JSON.stringify(spriteSheetData, null, 2),
   );
-});
+}
 
 function getTexturePath(
   spriteType: SpriteType,
@@ -84,7 +83,7 @@ function getTexturePath(
     texturesBasePath, // e.g. AWBW-Replay-Player/AWBWApp.Resources/Textures
     spriteSources[spriteType], // e.g. Units
     spriteNation, // e.g. OrangeStar
-    spriteName || "", // e.g. APC_MSide-2.png
+    spriteName ?? "", // e.g. APC_MSide-2.png
   );
 }
 
@@ -117,6 +116,8 @@ async function genFramesAndSpriteSheetImage(
    * Generates frames with appropriate dimensions for given sprites
    */
   const columnsCount = Math.round(Math.sqrt(allSprites.length));
+  // rows can exceed columns for non-square counts (e.g. 10 sprites → 3 cols × 4 rows), so the
+  // canvas height must be sized from rowsCount — using columnsCount clips the last row(s).
   const rowsCount = Math.ceil(allSprites.length / columnsCount);
 
   // compute max cell width and height
@@ -137,7 +138,7 @@ async function genFramesAndSpriteSheetImage(
   const spriteSheetImage = sharp({
     create: {
       width: columnsCount * cellWidth,
-      height: columnsCount * cellHeight,
+      height: rowsCount * cellHeight,
       channels: 4,
       background: { r: 0, g: 0, b: 0, alpha: 0 },
     },
@@ -162,10 +163,7 @@ async function genFramesAndSpriteSheetImage(
   return { spriteSheetImage, frames };
 }
 
-async function fetchAnimations(
-  allSprites: Sprite[],
-  frames: Record<string, ISpritesheetFrameData>,
-): Promise<Record<string, string[]>> {
+function fetchAnimations(allSprites: Sprite[]): Record<string, string[]> {
   const animationFrameRegex = /^(.*)-\d+\.png$/i; // capture pattern "Airport-1.png"
   const animationKeys = new Set(
     allSprites


### PR DESCRIPTION
Preparing chunked review for all modification. 

They will come from stack/XX-desc branches to be passed one by one. 

This one is the baseline, fixing lint and build on CI so all others will pass correctly. 
Those rules can be discussed. 

fetchAnimations was neither used as promise so dropped the useless async maping. 

the reassign to const is a bit trickier.  This happens in a callback where array was checked as non undefined BUT as it's a pot variable array, TS assumes that it can be modified BEFORE the callback is called, resulting in potential undefined array at this point. Matching locally to a const remove this pot issue. 